### PR TITLE
feat: 게임컨트롤러 컴포넌트 분리 및 노트 렌더링

### DIFF
--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -1,34 +1,50 @@
+/* eslint-disable react/no-array-index-key */
 import { io } from "socket.io-client";
 import React, { useState, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
+import GameController from "../GameController";
 
 export default function BattleRoom() {
   const params = useParams();
-  const [activeKey, setActiveKey] = useState("");
   const [songData, setSongData] = useState({});
+  const [roomData, setRoomData] = useState({});
   const [socket, setSocket] = useState();
   const [countdown, setCountdown] = useState(3);
   const [isPlaying, setIsPlaying] = useState(false);
-  const keys = ["S", "D", "F", "J", "K", "L"];
+  const [isCountingDown, setIsCountingDown] = useState(false);
   const audioRef = useRef(null);
+  const { roomId } = useParams();
 
-  const handleKeyDown = (event) => {
-    const key = event.key.toUpperCase();
-    if (keys.includes(key)) {
-      setActiveKey(key);
-    }
-  };
+  useEffect(() => {
+    const socketClient = io(`http://localhost:4000/battles/${roomId}`, {
+      query: { roomId },
+    });
+    setSocket(socketClient);
 
-  const handleKeyUp = (event) => {
-    const key = event.key.toUpperCase();
-    if (keys.includes(key)) {
-      setActiveKey("");
+    return () => {
+      socketClient.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    async function getSong() {
+      const response = await axios.get(
+        `http://localhost:8000/api/rooms/${roomId}`,
+      );
+
+      if (response.status === 200) {
+        setSongData(response.data.song);
+        setRoomData(response.data.room);
+      }
     }
-  };
+
+    getSong();
+  }, []);
 
   const handleStart = () => {
+    setIsCountingDown(true);
     const countdownTimer = setInterval(() => {
       setCountdown((prevCountdown) => prevCountdown - 1);
     }, 1000);
@@ -36,92 +52,36 @@ export default function BattleRoom() {
     setTimeout(() => {
       clearInterval(countdownTimer);
       setIsPlaying(true);
-      // Start playing the music here
+      audioRef.current.src = songData.audioURL;
+      audioRef.current.play();
     }, 3000);
   };
-
-  useEffect(() => {
-    const s = io(`http://localhost:4000/battles/${params.roomId}`);
-    setSocket(s);
-
-    return () => {
-      s.disconnect();
-    };
-  }, []);
-
-  useEffect(() => {
-    async function getSong() {
-      const response = await axios.get(
-        `http://localhost:8000/api/rooms/${params.roomId}`,
-      );
-
-      if (response.status === 200) {
-        setSongData(response.data.song);
-      }
-    }
-
-    getSong();
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [keys]);
-
-  useEffect(() => {
-    window.addEventListener("keyup", handleKeyUp);
-    return () => {
-      window.removeEventListener("keyup", handleKeyUp);
-    };
-  }, [keys]);
-
-  useEffect(() => {
-    if (audioRef.current) {
-      if (isPlaying) {
-        audioRef.current.src = songData.audioURL;
-        audioRef.current.play();
-      } else {
-        audioRef.current.pause();
-        audioRef.current.currentTime = 0;
-      }
-    }
-  }, [isPlaying]);
 
   return (
     <Container>
       <AudioContainer ref={audioRef} />
-      <StartButton onClick={handleStart}>Start</StartButton>
-      {countdown > 0 && <Count>{countdown}</Count>}
+      {!isCountingDown && (
+        <StartButton onClick={handleStart}>Start</StartButton>
+      )}
+      {isCountingDown && countdown > 0 && <Count>{countdown}</Count>}
       <BattleRoomContainer>
         <BattleUserContainer>
           <div>
             <GradingText>Good</GradingText>
             <CountText>12</CountText>
           </div>
-          {keys.map((key) => (
-            <LeftColumnContainer>
-              <Column active={key === activeKey} onKeyDown={handleKeyDown} />
-              <HitBar />
-              <KeyBox active={key === activeKey} onKeyDown={handleKeyDown}>
-                {key}
-              </KeyBox>
-            </LeftColumnContainer>
-          ))}
+          <Controller>
+            <GameController isPlaying={isPlaying} />
+          </Controller>
         </BattleUserContainer>
         <BattleUserContainer>
           <div>
             <GradingText>Good</GradingText>
             <CountText>12</CountText>
           </div>
-          {keys.map((key) => (
-            <RightColumnContainer>
-              <Column />
-              <HitBar />
-              <KeyBox>{key}</KeyBox>
-            </RightColumnContainer>
-          ))}
+          <Controller>
+            <GameController isPlaying={isPlaying} />
+          </Controller>
         </BattleUserContainer>
       </BattleRoomContainer>
       <BottomContainer>
@@ -158,15 +118,25 @@ const AudioContainer = styled.audio`
   display: hidden;
 `;
 
+const Controller = styled.div`
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+`;
+
 const Count = styled.div`
   position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
+  font-size: 2em;
+  padding: 10px 20px;
   top: 50%;
   left: 50%;
+  color: white;
   transform: translate(-50%, -50%);
+  z-index: 10;
 `;
 
 const StartButton = styled.div`
@@ -192,6 +162,7 @@ const StartButton = styled.div`
 
 const BattleRoomContainer = styled.div`
   display: flex;
+  flex: 11;
   justify-content: space-between;
   width: 100%;
   height: 100%;
@@ -202,42 +173,6 @@ const BattleUserContainer = styled.div`
   position: relative;
   width: 30%;
   height: 100%;
-`;
-
-const LeftColumnContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 98.5%;
-  width: 30%;
-  background-color: black;
-  border-top: 7px solid blue;
-  border-bottom: 7px solid blue;
-
-  :nth-child(2) {
-    border-left: 7px solid blue;
-  }
-
-  :last-child {
-    border-right: 7px solid blue;
-  }
-`;
-
-const RightColumnContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 98.5%;
-  width: 30%;
-  background-color: black;
-  border-top: 7px solid blue;
-  border-bottom: 7px solid blue;
-
-  :nth-child(2) {
-    border-left: 7px solid blue;
-  }
-
-  :last-child {
-    border-right: 7px solid blue;
-  }
 `;
 
 const GradingText = styled.div`
@@ -258,58 +193,17 @@ const CountText = styled.div`
   font-size: 5em;
 `;
 
-const Column = styled.div`
-  display: flex;
-  justify-content: center;
-  height: 80%;
-  border-right: 2px solid gray;
-
-  :last-child {
-    background-color: red;
-    border-right: none;
-  }
-
-  ${({ active }) =>
-    active &&
-    `
-    background: linear-gradient(
-      rgba(217, 217, 217, 0) 0%,
-      rgba(255, 74, 74, 0.75) 100%
-    );
-  `}
-`;
-
-const HitBar = styled.div`
-  width: 100%;
-  height: 3%;
-  background-color: orange;
-`;
-
-const KeyBox = styled.div`
-  display: flex;
-  width: 100%;
-  height: 20%;
-  justify-content: center;
-  align-items: center;
-  font-size: 5em;
-  color: white;
-  box-shadow: inset 0 0 0 5px white;
-
-  ${({ active }) =>
-    active &&
-    `
-    background: rgba(217, 217, 217, 0.25)
-  `}
-`;
-
 const BottomContainer = styled.div`
+  flex: 1;
   display: flex;
+  /* align-items: center; */
   justify-content: space-between;
 `;
 
 const ScoreContainer = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
   width: 50vw;
   background-color: gray;
   font-size: 2em;

--- a/src/components/GameController/index.js
+++ b/src/components/GameController/index.js
@@ -1,0 +1,198 @@
+/* eslint-disable no-unsafe-optional-chaining */
+/* eslint-disable no-shadow */
+/* eslint-disable react/no-array-index-key */
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import styled from "styled-components";
+import { NOTES, MILLISECOND, SPEED, KEYS } from "../../store/contants";
+
+export default function GameController({ isPlaying }) {
+  const [activeKey, setActiveKey] = useState("");
+  const timeRef = useRef(0);
+  const deltaRef = useRef(null);
+  const canvasRef = useRef(null);
+  const canvas = canvasRef.current;
+  const ctx = canvas?.getContext("2d");
+
+  const noteHeight = canvas?.width / (6 * 3 * 3);
+
+  const render = (ctx, note) => {
+    const columnWidth = canvas.width / KEYS.length;
+    const cornerRadius = 5;
+
+    const keyMappings = {
+      s: { positionX: columnWidth * 0, color: "red" },
+      d: { positionX: columnWidth * 1, color: "blue" },
+      f: { positionX: columnWidth * 2, color: "yellow" },
+      j: { positionX: columnWidth * 3, color: "purple" },
+      k: { positionX: columnWidth * 4, color: "orange" },
+      l: { positionX: columnWidth * 5, color: "skyblue" },
+    };
+
+    const mapping = keyMappings[note?.key];
+    if (mapping) {
+      note.positionX = mapping.positionX;
+      note.color = mapping.color;
+    }
+
+    ctx.fillStyle = `${note?.color}`;
+    ctx.beginPath();
+    ctx.moveTo(note.positionX + cornerRadius, note.positionY);
+    ctx.lineTo(note.positionX + columnWidth - cornerRadius, note.positionY);
+    ctx.quadraticCurveTo(
+      note.positionX + columnWidth,
+      note.positionY,
+      note.positionX + columnWidth,
+      note.positionY + cornerRadius,
+    );
+    ctx.lineTo(
+      note.positionX + columnWidth,
+      note.positionY + noteHeight - cornerRadius,
+    );
+    ctx.quadraticCurveTo(
+      note.positionX + columnWidth,
+      note.positionY + noteHeight,
+      note.positionX + columnWidth - cornerRadius,
+      note.positionY + noteHeight,
+    );
+    ctx.lineTo(note.positionX + cornerRadius, note.positionY + noteHeight);
+    ctx.quadraticCurveTo(
+      note.positionX,
+      note.positionY + noteHeight,
+      note.positionX,
+      note.positionY + noteHeight - cornerRadius,
+    );
+    ctx.lineTo(note.positionX, note.positionY + cornerRadius);
+    ctx.quadraticCurveTo(
+      note.positionX,
+      note.positionY,
+      note.positionX + cornerRadius,
+      note.positionY,
+    );
+    ctx.closePath();
+    ctx.fill();
+  };
+
+  const update = (now, delta, ctx, note) => {
+    const diffTimeBetweenAnimationFrame = (now - delta) / MILLISECOND;
+    if (note) {
+      note.positionY += diffTimeBetweenAnimationFrame * SPEED;
+    }
+
+    render(ctx, note);
+  };
+
+  const renderNotes = (now, delta, ctx, notes) => {
+    const notesArray = notes.sort((prev, next) => prev.time - next.time);
+
+    notesArray.forEach((note) => {
+      update(now, delta, ctx, note);
+    });
+  };
+
+  useEffect(() => {
+    let animationFrameId;
+
+    const updateNotes = () => {
+      const now = Date.now();
+
+      if (!deltaRef.current) {
+        deltaRef.current = now;
+      }
+
+      ctx?.clearRect(0, 0, canvas.width, canvas.height);
+      timeRef.current += (now - deltaRef.current) / MILLISECOND;
+      const visibleNotes = NOTES.filter((note) => note.time <= timeRef.current);
+      renderNotes(now, deltaRef.current, ctx, visibleNotes);
+      animationFrameId = requestAnimationFrame(updateNotes);
+
+      deltaRef.current = now;
+    };
+
+    if (isPlaying) {
+      updateNotes();
+    }
+
+    return () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [isPlaying]);
+
+  return (
+    <GameContainer>
+      <CanvasContainer ref={canvasRef} />
+      <ColumnsContainer>
+        {KEYS.map((key, index) => (
+          <Column key={index} index={index} />
+        ))}
+      </ColumnsContainer>
+      <HitBox />
+      <KeyBox>
+        {KEYS.map((key, index) => (
+          <React.Fragment key={index}>
+            <Key>{key.toUpperCase()}</Key>
+          </React.Fragment>
+        ))}
+      </KeyBox>
+    </GameContainer>
+  );
+}
+
+const GameContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+const CanvasContainer = styled.canvas`
+  flex: 7;
+  width: 100%;
+  /* height: 80%; */
+  background-color: black;
+  box-shadow: inset 0 0 0 5px white;
+`;
+
+const ColumnsContainer = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+`;
+
+const Column = styled.div`
+  position: absolute;
+  top: 5px;
+  left: ${({ index }) => `calc(100% / 6 * ${index})`};
+  background-color: rgba(255, 255, 255, 0.2);
+  width: ${({ index }) =>
+    index === 5 ? `calc(100% / 6 - 5px)` : `calc(100% / 6)`};
+  height: ${`calc(87.5% - 10px)`};
+  border-right: ${({ index }) => (index === 5 ? null : "2px solid gray")};
+`;
+
+const HitBox = styled.div`
+  position: absolute;
+  bottom: 12.5%;
+  background-color: rgba(255, 255, 255, 0.2);
+  width: 100%;
+  height: 3%;
+`;
+
+const KeyBox = styled.div`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+`;
+
+const Key = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2em;
+  color: white;
+  width: 100%;
+  box-shadow: inset 0 0 0 5px white;
+`;

--- a/src/components/RoomMaker/index.js
+++ b/src/components/RoomMaker/index.js
@@ -33,6 +33,7 @@ export default function RoomMaker() {
       const response = await axios.post("http://localhost:8000/api/rooms/new", {
         song: selectedSongData,
         createdBy: auth.currentUser.displayName,
+        email: auth.currentUser.email,
       });
 
       if (response.data.result === "ok") {

--- a/src/store/contants.js
+++ b/src/store/contants.js
@@ -1,0 +1,95 @@
+export const SPEED = 35;
+export const MILLISECOND = 1000;
+export const KEYS = ["s", "d", "f", "j", "k", "l"];
+export const NOTES = [
+  {
+    time: 0.6,
+    key: "s",
+    positionY: 0,
+  },
+  {
+    time: 0.65,
+    key: "d",
+    positionY: 0,
+  },
+  {
+    time: 1.2,
+    key: "f",
+    positionY: 0,
+  },
+  {
+    time: 1.25,
+    key: "j",
+    positionY: 0,
+  },
+  {
+    time: 1.95,
+    key: "k",
+    positionY: 0,
+  },
+  {
+    time: 2,
+    key: "l",
+    positionY: 0,
+  },
+  {
+    time: 2.3,
+    key: "k",
+    positionY: 0,
+  },
+  {
+    time: 2.35,
+    key: "l",
+    positionY: 0,
+  },
+  {
+    time: 2.95,
+    key: "s",
+    positionY: 0,
+  },
+  {
+    time: 3,
+    key: "d",
+    positionY: 0,
+  },
+  {
+    time: 3.25,
+    key: "f",
+    positionY: 0,
+  },
+  {
+    time: 3.35,
+    key: "j",
+    positionY: 0,
+  },
+  {
+    time: 3.95,
+    key: "s",
+    positionY: 0,
+  },
+  {
+    time: 4.05,
+    key: "d",
+    positionY: 0,
+  },
+  {
+    time: 4.55,
+    key: "f",
+    positionY: 0,
+  },
+  {
+    time: 4.65,
+    key: "j",
+    positionY: 0,
+  },
+  {
+    time: 4.95,
+    key: "f",
+    positionY: 0,
+  },
+  {
+    time: 5.95,
+    key: "j",
+    positionY: 0,
+  },
+];


### PR DESCRIPTION
## Description🎉
배틀룸 컴포넌트에서 게잉컨트롤러 컴포넌트 분리 후 
게임 컨트롤러를 canvas API 화 시킨 후 
시작 시간에 맞게 노트 렌더링 

<hr>

## Related Issues📝
히트 이벤트와 스코어 이벤트 추가 필요

<hr>

## Changes✅
컴포넌트라 상수 추가

<hr>

## Screenshot📸

![image](https://user-images.githubusercontent.com/113571767/225608776-423249da-827c-4b70-b5ec-59890331b238.png)

![image](https://user-images.githubusercontent.com/113571767/225608983-0cef50c7-da5e-4539-a985-5bc68b62821c.png)


