### PR TITLE
feat: 로비 룸리스트에 참여해 있는 인원표시 및 제한

### DIFF
--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import GameController from "../GameController";
 import { auth } from "../../features/api/firebaseApi";
-import { UPDATE_USER } from "../../store/constants";
+import { UPDATE_USER, USER_JOINED, USER_LEAVE } from "../../store/constants";
 
 export default function BattleRoom() {
   const [song, setSong] = useState({});
@@ -90,7 +90,7 @@ export default function BattleRoom() {
 
   useEffect(() => {
     if (socket) {
-      socket.on("user_joined", (user) => {
+      socket.on(USER_JOINED, (user) => {
         setCurrentUserList((prevUserList) => [...prevUserList, user]);
       });
     }
@@ -98,7 +98,7 @@ export default function BattleRoom() {
 
   useEffect(() => {
     if (socket) {
-      socket.on("user_leave", (user) => {
+      socket.on(USER_LEAVE, (user) => {
         setCurrentUserList((prevUserList) =>
           prevUserList.filter((users) => users.uid !== user.uid),
         );

--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import { useSelector } from "react-redux";
 import GameController from "../GameController";
 import { auth } from "../../features/api/firebaseApi";
+import { UPDATE_USER } from "../../store/constants";
 
 export default function BattleRoom() {
   const [song, setSong] = useState({});
@@ -14,16 +15,20 @@ export default function BattleRoom() {
   const [countdown, setCountdown] = useState(3);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isCountingDown, setIsCountingDown] = useState(false);
+  const [currentUserList, setCurrentUserList] = useState([]);
+  const [newUser, setNewUser] = useState({});
+
   const audioRef = useRef(null);
   const { roomId } = useParams();
   const score = useSelector((state) => state.game.score);
+
+  const { displayName, photoURL, uid } = newUser;
 
   const handleStart = () => {
     setIsCountingDown(true);
     const countdownTimer = setInterval(() => {
       setCountdown((prevCountdown) => prevCountdown - 1);
     }, 1000);
-
     setTimeout(() => {
       clearInterval(countdownTimer);
       setIsPlaying(true);
@@ -33,15 +38,32 @@ export default function BattleRoom() {
   };
 
   useEffect(() => {
+    if (auth && auth.currentUser) {
+      const { displayName, photoURL, uid } = auth.currentUser;
+
+      setNewUser({
+        displayName,
+        photoURL,
+        uid,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
     const socketClient = io(`${process.env.REACT_APP_SOCKET_URL}/battles/`, {
-      query: { roomId },
+      query: {
+        roomId,
+        name: displayName,
+        picture: photoURL,
+        uid,
+      },
     });
     setSocket(socketClient);
 
     return () => {
       socketClient.disconnect();
     };
-  }, [roomId]);
+  }, [displayName, photoURL, roomId, uid]);
 
   useEffect(() => {
     const getSong = async () => {
@@ -58,6 +80,31 @@ export default function BattleRoom() {
     getSong();
   }, [roomId]);
 
+  useEffect(() => {
+    if (socket) {
+      socket.on(UPDATE_USER, (currentUserList) => {
+        setCurrentUserList(currentUserList);
+      });
+    }
+  }, [socket]);
+
+  useEffect(() => {
+    if (socket) {
+      socket.on("user_joined", (user) => {
+        setCurrentUserList((prevUserList) => [...prevUserList, user]);
+      });
+    }
+  }, [socket]);
+
+  useEffect(() => {
+    if (socket) {
+      socket.on("user_leave", (user) => {
+        setCurrentUserList((prevUserList) =>
+          prevUserList.filter((users) => users.uid !== user.uid),
+        );
+      });
+    }
+  }, [socket]);
   return (
     <Container song={song}>
       <AudioContainer ref={audioRef} />

--- a/src/components/Lobby/index.js
+++ b/src/components/Lobby/index.js
@@ -22,6 +22,7 @@ export default function Lobby() {
   const [roomsList, setRoomsList] = useState([]);
   const [chatMessage, setChatMessage] = useState("");
   const [receivedMessages, setReceivedMessages] = useState([]);
+  const [connectedUsers, setConnectedUsers] = useState({});
 
   const chatListRef = useRef(null);
 
@@ -50,6 +51,18 @@ export default function Lobby() {
       }
     },
     [chatMessage, displayName, socket],
+  );
+
+  const handleRoomClick = useCallback(
+    (roomId) => {
+      const targetUser = connectedUsers[roomId];
+      if (targetUser && Object.keys(targetUser).length === 2) {
+        alert("Room is full");
+      } else {
+        navigate(`/battles/${roomId}`);
+      }
+    },
+    [connectedUsers, navigate],
   );
 
   const handleLogout = async () => {
@@ -235,6 +248,14 @@ export default function Lobby() {
     scrollToBottom();
   }, [receivedMessages, scrollToBottom]);
 
+  useEffect(() => {
+    if (socket) {
+      socket.on("check_users", (users) => {
+        setConnectedUsers(users);
+      });
+    }
+  }, [socket]);
+
   return (
     <Background>
       <HeaderContainer>
@@ -246,12 +267,17 @@ export default function Lobby() {
           <RoomsContainer>
             <RoomsLists>
               {roomsList.length &&
-                roomsList.map(({ _id, createdBy, song }) => (
-                  <Room key={_id}>
-                    <RoomName>{createdBy}</RoomName>
-                    <RoomSong>{song?.title}</RoomSong>
-                  </Room>
-                ))}
+                roomsList.map(({ _id, createdBy, song }) => {
+                  const targetUser = connectedUsers[_id];
+                  return (
+                    <Room key={_id} onClick={() => handleRoomClick(_id)}>
+                      <RoomName>{`${createdBy} ${
+                        targetUser ? Object.keys(targetUser).length : 0
+                      }/2`}</RoomName>
+                      <RoomSong>{song?.title}</RoomSong>
+                    </Room>
+                  );
+                })}
             </RoomsLists>
           </RoomsContainer>
           <ChatContainer>

--- a/src/components/Lobby/index.js
+++ b/src/components/Lobby/index.js
@@ -10,6 +10,7 @@ import {
   SEND_CHAT,
   BROADCAST_CHAT,
   UPDATE_USER,
+  CHECK_USERS,
 } from "../../store/constants";
 
 export default function Lobby() {
@@ -250,7 +251,7 @@ export default function Lobby() {
 
   useEffect(() => {
     if (socket) {
-      socket.on("check_users", (users) => {
+      socket.on(CHECK_USERS, (users) => {
         setConnectedUsers(users);
       });
     }

--- a/src/components/RoomMaker/index.js
+++ b/src/components/RoomMaker/index.js
@@ -12,7 +12,7 @@ export default function RoomMaker() {
   const [selectedSong, setSelectedSong] = useState(null);
   const audioRef = useRef(null);
 
-  const handleSelecet = (roomId) => {
+  const handleSelect = (roomId) => {
     setSelectedSong((prev) => (prev === roomId ? null : roomId));
   };
 
@@ -105,7 +105,7 @@ export default function RoomMaker() {
           key={song._id}
           onMouseEnter={() => setHoveredSong(song)}
           onMouseLeave={() => setHoveredSong(null)}
-          onClick={() => handleSelecet(song._id)}
+          onClick={() => handleSelect(song._id)}
         >
           <ProfileImage src={song.imageURL} />
           <SongTitleText>

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -4,6 +4,9 @@ export const BROADCAST_CHAT = "broadcast-chat";
 export const UPDATE_USER = "update-user";
 export const SEND_BATTLES = "send-battles";
 export const RECEIVE_BATTLES = "receive-battles";
+export const USER_JOINED = "user_joined";
+export const USER_LEAVE = "user_leave";
+export const CHECK_USERS = "check_users";
 
 export const SPEED = 300;
 export const MILLISECOND = 1000;


### PR DESCRIPTION
## 📝 Description
> ### `socket.io`
>- `USER_JOINED `는 유저가 입장할때 실행하는 소켓 이벤트 입니다.
>- `USER_LEAVE`는 유저가 나갈때 실행하는 소켓 이벤트 입니다.
>- `CHECK_USERS`는 유저가 현재 어떤 방에 몇명있는지 확인하는 소켓이벤트 입니다.
해당 **BattleRoom**에 입장해 있는 유저의 정보는 `currentUserList` `state`로 확인 가능합니다.
Lobby 에서 `connectedUsers` `state`로 현재 각각의 방에 입장하고 있는 유저의 정보를 실시간으로 저장합니다. 
>해당 방에 2명 이라면 방을 클릭해도 참여하지못하고 `방이 모두 찼습니다.` 라는 알림창이 등장합니다.

## ❗ Related Issues
battle 페이지에서 새로고침은 하면 유저가 `disconnect` 되여 해당 유저가 `undefined` 상황을 발견하였습니다. 저의 해결방안 생각으로는 새로고침이 된다면 useNavigate로 메인페이지로 이동시키는 방법을 생각하고 있습니다.

## 🛠️ Changes
- `currentUser` `state` 네이밍을 `currentUserList`로 명확하게 바꾸어 주었습니다.
아래 상수를 추가 해주었습니다.
- `USER_JOINED` = `"user_joined"`
- `USER_LEAVE` = `"user_leave"`
- `CHECK_USERS` = `"check_users"`

## 📸 Screenshot
<img width="400" alt="스크린샷 2023-03-20 오후 8 52 21" src="https://user-images.githubusercontent.com/107290583/226331864-e5b7f273-ff66-44b3-b18d-d772c714a32b.png">
