### PR TITLE
feat: audioVisualizer 컴포넌트화, 오디오 시각화 구현

### DIFF
--- a/src/components/AudioVisualizer/index.js
+++ b/src/components/AudioVisualizer/index.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 export default function AudioVisualizer({ song, isPlaying }) {
   const navigate = useNavigate();
   const [audioBuffer, setAudioBuffer] = useState(null);
+  const audioSourceRef = useRef(null);
   const createAudioContextAndSource = useCallback((audioBuffer) => {
     const audioContext = new AudioContext();
     const source = audioContext.createBufferSource();
@@ -19,6 +20,7 @@ export default function AudioVisualizer({ song, isPlaying }) {
 
   const startVisualization = useCallback(async () => {
     const { audioContext, source } = createAudioContextAndSource(audioBuffer);
+    audioSourceRef.current = source;
     await audioContext.resume();
     const analyser = audioContext.createAnalyser();
     analyser.fftSize = 256;
@@ -118,6 +120,12 @@ export default function AudioVisualizer({ song, isPlaying }) {
     source.start(0);
   }, [audioBuffer, createAudioContextAndSource]);
 
+  const stopAudio = useCallback(() => {
+    if (audioSourceRef.current) {
+      audioSourceRef.current.stop();
+    }
+  }, []);
+
   const getBuffer = useCallback(async () => {
     if (song?.audioURL) {
       try {
@@ -150,27 +158,29 @@ export default function AudioVisualizer({ song, isPlaying }) {
   }, [createAudioContextAndSource, navigate, song?.audioURL]);
 
   useEffect(() => {
-    if (isPlaying) {
-      startVisualization();
-    }
-  }, [isPlaying, startVisualization]);
-
-  useEffect(() => {
     if (song?.audioURL) {
       getBuffer();
     }
-  }, [getBuffer, song?.audioURL]);
+
+    return stopAudio;
+  }, [getBuffer, song?.audioURL, stopAudio]);
+
+  useEffect(() => {
+    if (isPlaying && audioBuffer) {
+      startVisualization();
+    }
+  }, [audioBuffer, isPlaying, startVisualization]);
 
   return (
     <CanvasWrapper>
-      <canvas id="audio-visualizer" width="1900" height="880" />
+      <canvas id="audio-visualizer" width="1920" height="1000" />
     </CanvasWrapper>
   );
 }
 
 const CanvasWrapper = styled.div`
   position: absolute;
-  top: 45%;
+  top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   display: flex;

--- a/src/components/AudioVisualizer/index.js
+++ b/src/components/AudioVisualizer/index.js
@@ -1,0 +1,179 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import styled from "styled-components";
+
+export default function AudioVisualizer({ song, isPlaying }) {
+  const navigate = useNavigate();
+  const [audioBuffer, setAudioBuffer] = useState(null);
+  const createAudioContextAndSource = useCallback((audioBuffer) => {
+    const audioContext = new AudioContext();
+    const source = audioContext.createBufferSource();
+
+    if (audioBuffer) {
+      source.buffer = audioBuffer;
+    }
+
+    return { audioContext, source };
+  }, []);
+
+  const startVisualization = useCallback(async () => {
+    const { audioContext, source } = createAudioContextAndSource(audioBuffer);
+    await audioContext.resume();
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 256;
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+
+    source.connect(analyser);
+    analyser.connect(audioContext.destination);
+
+    const canvas = document.getElementById("audio-visualizer");
+    const ctx = canvas.getContext("2d");
+    const { width } = canvas;
+    const { height } = canvas;
+
+    const particles = [];
+
+    const draw = () => {
+      requestAnimationFrame(draw);
+
+      analyser.getByteTimeDomainData(dataArray);
+
+      ctx.clearRect(0, 0, width, height);
+
+      ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+      ctx.fillRect(0, 0, width, height);
+
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const baseRadius = 80;
+
+      const averageAmplitude =
+        dataArray.reduce((acc, value) => acc + value, 0) / dataArray.length;
+
+      const scaleFactor = 1 + averageAmplitude / 255;
+      const innerCircleRadius = baseRadius * scaleFactor;
+
+      ctx.beginPath();
+      let angle = -Math.PI / 2;
+
+      for (let i = 0; i < bufferLength - 1; i++) {
+        const v = dataArray[i] / 128.0;
+        const radius = innerCircleRadius + v * 50;
+        const x = centerX + radius * Math.cos(angle);
+        const y = centerY + radius * Math.sin(angle);
+
+        if (i === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+
+        const angleIncrement = (2 * Math.PI) / (bufferLength - 1);
+
+        angle += angleIncrement;
+      }
+
+      ctx.closePath();
+      ctx.strokeStyle = "rgba(255, 255, 255, 1)";
+      ctx.lineWidth = 3;
+      ctx.stroke();
+
+      const numParticles = Math.floor(averageAmplitude / 120);
+      const maxAmplitude = Math.max(...dataArray);
+      const speedScaleFactor = 1;
+      const particleSpeed = (maxAmplitude / 128.0) * speedScaleFactor;
+      const particleRadius = 2;
+      const particleColor = `rgba(255, 255, 255, 0.8)`;
+
+      for (let i = 0; i < numParticles; i++) {
+        const angle = Math.random() * 2 * Math.PI;
+        const radius =
+          innerCircleRadius +
+          (dataArray[Math.floor((i / numParticles) * bufferLength)] / 128.0) *
+            50;
+
+        const x = centerX + radius * Math.cos(angle);
+        const y = centerY + radius * Math.sin(angle);
+        const vx = Math.cos(angle) * particleSpeed;
+        const vy = Math.sin(angle) * particleSpeed;
+
+        particles.push({ x, y, vx, vy, particleColor });
+      }
+
+      particles.forEach((particle) => {
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+
+        ctx.beginPath();
+        ctx.arc(particle.x, particle.y, particleRadius, 0, 2 * Math.PI);
+        ctx.fillStyle = particleColor;
+        ctx.fill();
+      });
+    };
+
+    draw();
+
+    source.start(0);
+  }, [audioBuffer, createAudioContextAndSource]);
+
+  const getBuffer = useCallback(async () => {
+    if (song?.audioURL) {
+      try {
+        const response = await axios.get(
+          "http://localhost:8000/proxy/audio-server",
+          {
+            responseType: "arraybuffer",
+            params: { url: song?.audioURL },
+          },
+        );
+
+        if (response.status === 200) {
+          const audioData = new Uint8Array(response.data).buffer;
+          const { audioContext, source } = createAudioContextAndSource(null);
+
+          const buffer = await audioContext.decodeAudioData(audioData);
+          setAudioBuffer(buffer);
+          source.buffer = buffer;
+        }
+      } catch (err) {
+        navigate("/error", {
+          state: {
+            status: err.response.status,
+            text: err.response.statusText,
+            message: err.message,
+          },
+        });
+      }
+    }
+  }, [createAudioContextAndSource, navigate, song?.audioURL]);
+
+  useEffect(() => {
+    if (isPlaying) {
+      startVisualization();
+    }
+  }, [isPlaying, startVisualization]);
+
+  useEffect(() => {
+    if (song?.audioURL) {
+      getBuffer();
+    }
+  }, [getBuffer, song?.audioURL]);
+
+  return (
+    <CanvasWrapper>
+      <canvas id="audio-visualizer" width="1900" height="880" />
+    </CanvasWrapper>
+  );
+}
+
+const CanvasWrapper = styled.div`
+  position: absolute;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;

--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -1,12 +1,14 @@
 import { io } from "socket.io-client";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
 import { useSelector } from "react-redux";
-import GameController from "../GameController";
 import { auth } from "../../features/api/firebaseApi";
 import { UPDATE_USER, USER_JOINED, USER_LEAVE } from "../../store/constants";
+
+import GameController from "../GameController";
+import AudioVisualizer from "../AudioVisualizer";
 
 export default function BattleRoom() {
   const [song, setSong] = useState({});
@@ -105,9 +107,11 @@ export default function BattleRoom() {
       });
     }
   }, [socket]);
+
   return (
     <Container song={song}>
       <AudioContainer ref={audioRef} />
+      <AudioVisualizer song={song} isPlaying={isPlaying} />
       {!isCountingDown && (
         <StartButton onClick={handleStart}>Start</StartButton>
       )}

--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -1,5 +1,5 @@
 import { io } from "socket.io-client";
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import styled from "styled-components";
@@ -20,7 +20,6 @@ export default function BattleRoom() {
   const [currentUserList, setCurrentUserList] = useState([]);
   const [newUser, setNewUser] = useState({});
 
-  const audioRef = useRef(null);
   const { roomId } = useParams();
   const score = useSelector((state) => state.game.score);
 
@@ -34,8 +33,6 @@ export default function BattleRoom() {
     setTimeout(() => {
       clearInterval(countdownTimer);
       setIsPlaying(true);
-      audioRef.current.src = song.audioURL;
-      audioRef.current.play();
     }, 3000);
   };
 
@@ -110,7 +107,6 @@ export default function BattleRoom() {
 
   return (
     <Container song={song}>
-      <AudioContainer ref={audioRef} />
       <AudioVisualizer song={song} isPlaying={isPlaying} />
       {!isCountingDown && (
         <StartButton onClick={handleStart}>Start</StartButton>
@@ -157,10 +153,6 @@ const Container = styled.main`
   background-size: cover;
   background-position: center;
   box-sizing: border-box;
-`;
-
-const AudioContainer = styled.audio`
-  display: hidden;
 `;
 
 const Controller = styled.div`

--- a/src/components/GameController/index.js
+++ b/src/components/GameController/index.js
@@ -14,6 +14,7 @@ import {
   updateTotalScore,
   updateScore,
   updateCombo,
+  isSongEnd,
 } from "../../features/reducers/gameSlice";
 import {
   NOTES,
@@ -288,6 +289,7 @@ export default function GameController({ isPlaying }) {
     dispatch(updateScore(currentScore));
 
     if (songEnd) {
+      dispatch(isSongEnd());
       dispatch(updateCombo(comboResults));
       dispatch(updateTotalScore(currentScore));
       navigate("/battles/results");

--- a/src/features/reducers/gameSlice.js
+++ b/src/features/reducers/gameSlice.js
@@ -8,6 +8,7 @@ const initialState = {
     good: 0,
     miss: 0,
   },
+  end: false,
 };
 
 export const gameSlice = createSlice({
@@ -23,8 +24,12 @@ export const gameSlice = createSlice({
     updateCombo: (state, action) => {
       state.combo = action.payload;
     },
+    isSongEnd: (state) => {
+      state.end = true;
+    },
   },
 });
 
-export const { updateScore, updateTotalScore, updateCombo } = gameSlice.actions;
+export const { updateScore, updateTotalScore, updateCombo, isSongEnd } =
+  gameSlice.actions;
 export default gameSlice.reducer;


### PR DESCRIPTION
## 📝 Description

- `BattleRoom` 안에서 재생되는 오디오를 분석해 시각화하기 위해 `Web Audio API`를 이용하여 시각화하였습니다. 
- 노래가 진행됨에 따라서 사용자에게 시각적인 효과를 주기 위해 배틀룸의 배경으로 각 방의 설정된 오디오 파일을 시각화해 중앙에 보여줍니다.
- 중앙에 원이 크기가 오디오의 시간분석에 따라 크기가 변하고 모양이 찌그러졌다 펴집니다. 
- 배경으로 투명한 검정색 필터를 주어서 하얀색인 시각화 요소들이 더 잘 보일 수 있도록 하였습니다. 
- 원의 표면에서 입자가 방출되게 하였습니다. 

## ❗ Related Issues

- `const audioData = new Uint8Array(song.audioURL).buffer`에서 CORS 문제가 발생해 오디오를 `Web Audio API` 로딩하여 분석하는데 문제가 있어서 오디오 프록시 서버를 만들어서 해결하였습니다. 
- 원에서 방출되는 입자의 속도를 오디오데이터의 변화에 맞추어서 빨라졌다 느려지게 속도를 조절하여야 합니다. 
- 현재 원이 중앙에 하나만 위치하지만 원의 바깥에 오디오 파형으로 감싸진 원을 하나더 추가하면 더 좋을 것 같습니다. 

## 🛠️ Changes

- 기존에 있던 `audioRef`와 `audioContainer` 대신 오디오 시각화와 관련된 요소의 컴포넌트 `audioVisualizer`를 만들었습니다.
- `audioVisualizer` 컴포넌트에서 부모 컴포넌트인 `BattleRoom`에서  노래정보 `song`와 노래재생여부 `isPlaying`을 받아옵니다. `startVisualization` 함수 내부에서 그림을 그릴 캔버스와 오디오파일로 생성된 오디오버퍼를 세팅하고 `draw` 함수로 시각화를 합니다. 
- `gameSlice`에 노래가 끝났는지에 대한 `boolean` 상태 글로벌 변수인`isSongEnd`를 추가해주었습니다. 

## 📸 Screenshot
<img src="https://user-images.githubusercontent.com/115068443/226654897-7bc6edb7-7c65-415a-9f99-458e32fc9ba0.png" alt="image-description" width="400">

