### PR TITLE
feat: 배틀룸 결과 창 소켓통한 구현

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -23,8 +23,11 @@ export default function App() {
         <Route path="/login" element={loading ? <Loading /> : <Login />} />
         <Route path="/" element={<Lobby />} />
         <Route path="/battles/new" element={<RoomMaker />} />
-        <Route path="/battles/:roomId" element={<BattleRoom />} />
-        <Route path="/battles/results" element={<BattleResults />} />
+        <Route
+          path="/battles/:roomId"
+          element={loading ? <Loading /> : <BattleRoom />}
+        />
+        <Route path="/battles/results/:resultId" element={<BattleResults />} />
         <Route path="/error" element={<Error />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/components/BattleResults/index.js
+++ b/src/components/BattleResults/index.js
@@ -1,33 +1,49 @@
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
 import { io } from "socket.io-client";
 import styled from "styled-components";
 import { auth } from "../../features/api/firebaseApi";
 
 export default function BattleResults() {
-  const combo = useSelector((state) => state.game.combo);
+  const comboResults = useSelector((state) => state.game.comboResults);
   const totalScore = useSelector((state) => state.game.totalScore);
-  const roomId = useSelector((state) => state.game.roomid);
   const [socket, setSocket] = useState();
+  const [battleUserProfile, setBattleUserProfile] = useState({});
+  const [battleUserResults, setBattleUserResults] = useState({});
+  const { resultId } = useParams();
 
   const { displayName, photoURL, uid } = auth.currentUser
     ? auth.currentUser
     : { displayName: null, photoURL: null, uid: null };
 
+  socket?.emit("send-results", comboResults, totalScore);
+
   useEffect(() => {
-    const socketClient = io(`${process.env.REACT_APP_SOCKET_URL}/`, {
+    socket?.on("receive-results", (comboResults, totalScore, user) => {
+      setBattleUserResults(comboResults);
+      setBattleUserProfile({ totalScore, user });
+    });
+
+    socket?.on("user-out", () => {
+      console.log("User Is out");
+    });
+  }, [comboResults, resultId, socket, totalScore]);
+
+  useEffect(() => {
+    const socketClient = io(`${process.env.REACT_APP_SOCKET_URL}/results/`, {
       cors: {
         origin: "*",
         methods: ["GET", "POST"],
       },
-      query: { displayName, photoURL, uid, roomId },
+      query: { displayName, photoURL, uid, resultId },
     });
     setSocket(socketClient);
 
     return () => {
       socketClient.disconnect();
     };
-  }, [displayName, photoURL, roomId, uid]);
+  }, [displayName, photoURL, resultId, uid]);
 
   return (
     <BattleResultsContainer>
@@ -39,10 +55,10 @@ export default function BattleResults() {
             <UserImage src={photoURL} />
             <ResultsBox>{displayName}</ResultsBox>
           </UserContainer>
-          {Object.keys(combo).map((key) => (
+          {Object.keys(comboResults).map((key) => (
             <RecordsContainer key={key}>
               <ResultsBox>{key}</ResultsBox>
-              <Score>{combo[key]}</Score>
+              <Score>{comboResults[key]}</Score>
             </RecordsContainer>
           ))}
           <StyledHr />
@@ -54,19 +70,23 @@ export default function BattleResults() {
         <ResultPanel>
           <Winner>Winner</Winner>
           <UserContainer>
-            <UserImage src={photoURL} />
-            <ResultsBox>{displayName}</ResultsBox>
+            <UserImage
+              src={battleUserProfile && battleUserProfile?.user?.photoURL}
+            />
+            <ResultsBox>
+              {battleUserProfile && battleUserProfile?.user?.displayName}
+            </ResultsBox>
           </UserContainer>
-          {Object.keys(combo).map((key) => (
+          {Object.keys(battleUserResults).map((key) => (
             <RecordsContainer key={key}>
               <ResultsBox>{key}</ResultsBox>
-              <Score>{combo[key]}</Score>
+              <Score>{battleUserResults[key]}</Score>
             </RecordsContainer>
           ))}
           <StyledHr />
           <RecordsContainer>
             <ResultsBox>TotalScore: </ResultsBox>
-            <Score>{totalScore}</Score>
+            <Score>{battleUserProfile && battleUserProfile?.totalScore}</Score>
           </RecordsContainer>
         </ResultPanel>
       </ResultsWrapper>

--- a/src/components/BattleResults/index.js
+++ b/src/components/BattleResults/index.js
@@ -4,6 +4,7 @@ import { useParams } from "react-router-dom";
 import { io } from "socket.io-client";
 import styled from "styled-components";
 import { auth } from "../../features/api/firebaseApi";
+import { RECEIVE_RESULTS, SEND_RESULTS, USER_OUT } from "../../store/constants";
 
 export default function BattleResults() {
   const comboResults = useSelector((state) => state.game.comboResults);
@@ -17,16 +18,16 @@ export default function BattleResults() {
     ? auth.currentUser
     : { displayName: null, photoURL: null, uid: null };
 
-  socket?.emit("send-results", comboResults, totalScore);
+  socket?.emit(SEND_RESULTS, comboResults, totalScore);
 
   useEffect(() => {
-    socket?.on("receive-results", (comboResults, totalScore, user) => {
+    socket?.on(RECEIVE_RESULTS, (comboResults, totalScore, user) => {
       setBattleUserResults(comboResults);
       setBattleUserProfile({ totalScore, user });
     });
 
-    socket?.on("user-out", () => {
-      console.log("User Is out");
+    socket?.on(USER_OUT, () => {
+      console.log("User is out");
     });
   }, [comboResults, resultId, socket, totalScore]);
 

--- a/src/components/BattleRoom/index.js
+++ b/src/components/BattleRoom/index.js
@@ -431,8 +431,9 @@ const ProfileContainer = styled.div`
   position: relative;
   align-items: center;
   justify-content: space-between;
+  font-size: 2.5vw;
   width: 100%;
-  height: 100%;
+  height: 80%;
   padding: 10px;
 `;
 

--- a/src/components/GameController/index.js
+++ b/src/components/GameController/index.js
@@ -309,7 +309,7 @@ export default function GameController({
 
       renderNotes(now, deltaRef.current, ctx, visibleNotes);
 
-      if (timeRef.current >= songDuration) {
+      if (timeRef.current >= songDuration + 5) {
         navigate(`/battles/results/${roomId}`);
 
         if (

--- a/src/features/reducers/gameSlice.js
+++ b/src/features/reducers/gameSlice.js
@@ -3,7 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 const initialState = {
   score: 0,
   totalScore: 0,
-  combo: {
+  comboResults: {
     excellent: 0,
     good: 0,
     miss: 0,
@@ -11,7 +11,6 @@ const initialState = {
   currentCombo: 0,
   end: false,
   word: "",
-  roomId: "",
 };
 
 export const gameSlice = createSlice({
@@ -28,9 +27,21 @@ export const gameSlice = createSlice({
       state.word = action.payload;
     },
     isSongEnd: (state, action) => {
-      state.roomId = action.payload.roomId;
-      state.totalScore = action.payload.currentScore;
-      state.combo = action.payload.comboResults;
+      const { comboResults, currentScore, maxNotesNumber } = action.payload;
+
+      const missNumber =
+        maxNotesNumber - (comboResults.excellent + comboResults.good);
+
+      console.log(maxNotesNumber);
+
+      const results = {
+        excellent: comboResults.excellent,
+        good: comboResults.good,
+        miss: missNumber,
+      };
+
+      state.totalScore = currentScore;
+      state.comboResults = results;
       state.end = true;
     },
   },

--- a/src/features/reducers/gameSlice.js
+++ b/src/features/reducers/gameSlice.js
@@ -32,8 +32,6 @@ export const gameSlice = createSlice({
       const missNumber =
         maxNotesNumber - (comboResults.excellent + comboResults.good);
 
-      console.log(maxNotesNumber);
-
       const results = {
         excellent: comboResults.excellent,
         good: comboResults.good,

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -11,6 +11,9 @@ export const SEND_CONNECT = "send-connect";
 export const SEND_BATTLES = "send-battles";
 export const SEND_USER = "send-user";
 export const SEND_READY = "send-ready";
+export const SEND_RESULTS = "send-results";
+
+export const RECEIVE_RESULTS = "receive-results";
 export const RECEIVE_BATTLES = "receive-battles";
 export const RECEIVE_USER = "receive-user";
 export const RECEIVE_LOBBY_USERS = "receive-lobby-users";
@@ -23,9 +26,10 @@ export const RECEIVE_OPPONENT_KEY_RELEASE = "receive-opponent-key-release";
 export const RECEIVE_DELETE = "receive-delete";
 export const RECEIVE_READY = "receive-ready";
 export const RECEIVE_START = "receive-start";
-export const ROOM_FULL = "room-full";
 
+export const ROOM_FULL = "room-full";
 export const DELETE_ROOM = "delete-room";
+export const USER_OUT = "user-out";
 
 export const SPEED = 500;
 export const MILLISECOND = 1000;


### PR DESCRIPTION
## 📝 Description
- 배틀룸 결과창을 소켓을 이용해 실시간으로 구현하였습니다.
```javascript
   navigate(`/battles/results/${roomId}`);
  
    if (
      !songHasEnded &&
      (comboResults.excellent > 0 || comboResults.good > 0)
    ) {
      dispatch(isSongEnd({ comboResults, currentScore, maxNotesNumber }));
    }
  
    setSongHasEnded(true);
```
이 부분에서 `navigate`를 먼저 실행 시킨 뒤  `dispatch`를 하는 로직으로 구현하였습니다.
조건문을 설정 전 `navigate`를 먼저 적용 시키고 `dispatch`를 해야 배틀룸의 정보를 `store`로 보낼 수 있어 `BattleResults`에서 받을 수 있다고 판단하였습니다. 
현재 로직이 비동기적으로 이루어지는 부분이 많아 예측하거나 원하는 결과값을 받는 것이 어려워 많은 조건문을 설정하였습니다.

## ❗ Related Issues
- 결과에 대한 기록화가 필요할 경우 mongoDB를 이용해 서버와 통신할 필요가 있습니다.
- 승자와 패자에 대한 동적 구현, 그리고 기록화 그리고 나가기 버튼에 대한 구현이 필요합니다.
- 많은 비동기 `useEffect`로 인해 함수 내부의 결과값이 예측하기 어려워짐에 따라 디자인패턴화와 리팩토링이 필요합니다. 
- 배틀룸에 처음 들어갈 경우 노트 정보가 많아 백지 화면이 처음에 몇초가량 뜨고 로딩된 후 뜨는 상태가 발견됐습니다. 이에 따라 로딩 창 혹은 다른 리듬게임 일러스트 이미지를 몇초간 보여준 뒤 배틀룸으로 보낼 필요가 있어 보입니다.

## 🛠️ Changes
- 하나의 `dispatch`에서 노래가 끝났을 경우에 대한 처리를 전부다 해주는 것으로 변경하였습니다.
- 하나의 `action`에는 하나의 `dispatch`만 설정 하는 `Redux`의 기본 원칙을 적용하였습니다.

## 📸 Screenshot

![image](https://user-images.githubusercontent.com/113571767/227206210-27493c00-f543-4cd7-9e1b-c0bf47800778.png)

